### PR TITLE
Fixed JSON-LD syntax and description tag

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -87,7 +87,13 @@ export default ({ app }) => {
     // Flatten metaTagContainer values into string
     const meta = metaTagContainer
       ? Object.values(metaTagContainer).reduce(
-          (flat, next) => flat.concat(next),
+          {
+            if (next.name === 'description') {
+              // Override description tag with updated description
+              next.hid = 'description';
+            }
+            return flat.concat(next);
+          },
           [],
         )
       : null
@@ -111,7 +117,7 @@ export default ({ app }) => {
     const jsonLd = metaJsonLdContainer
       ? Object.entries(metaJsonLdContainer).map(value => ({
           type: 'application/ld+json',
-          innerHTML: JSON.stringify(value),
+          innerHTML: JSON.stringify(value[1]),
         }))
       : []
 


### PR DESCRIPTION
Hey Ben, I didn't use this plugin since I'm loading my somatic stuff differently, but I grabbed everything from line 70 down and added it to a custom script which seems to work as intended.

After running my Nuxt site through Google’s URL inspector it caught a syntax error with the JSON-LD script tags. I think what's getting stringified was an array instead of just the value of the object, (I was seeing `["breadcrumbList","{BREADCRUMB_VALUES}"]` instead of just `"{BREADCRUMB_VALUES}"`. Line 120 should fix that, but maybe a sanity check might be good there, too.

Regarding the "description" meta tag, I noticed it wasn’t overriding the default one picked up in my HTML template, so adding a `hid` set to "description" should do the trick there.